### PR TITLE
Update get.sources.sh

### DIFF
--- a/scripts/get.sources.sh
+++ b/scripts/get.sources.sh
@@ -34,12 +34,12 @@ get_sources () {
 	if [ ! -f "poco-${POCO_VERSION}-all.tar.gz" ] ; then wget https://pocoproject.org/releases/poco-${POCO_RELEASE}/poco-${POCO_VERSION}-all.tar.gz ; fi
 
 	cd ${SRC_DIR}
-	if [ ! -d "core" ] ; then git clone https://github.com/LibreOffice/core.git ; fi
+	if [ ! -d "core/.git" ] ; then git clone https://github.com/LibreOffice/core.git ; fi
 	cd core
 	git fetch --all --tags --prune
 
 	cd ${SRC_DIR}
-	if [ ! -d "online" ] ; then git clone https://github.com/LibreOffice/online.git ; fi
+	if [ ! -d "online/.git" ] ; then git clone https://github.com/LibreOffice/online.git ; fi
 	cd online
 	git fetch --all --tags --prune
 


### PR DESCRIPTION
build-lool.sh is creating the directories core and online in line 41 and 42 atm. so the checks if the directories exists will always be true and the git clone won't be execeuted. I changed it to "check if core/.git" directory is available and if not run the git clone, otherwise change into and fetch.

This should solve Issue #6 